### PR TITLE
Task priority logic invert

### DIFF
--- a/Python Match Simulator/MatchSim.py
+++ b/Python Match Simulator/MatchSim.py
@@ -408,17 +408,17 @@ def task_selection(robot, robot_type, time_left):
         endgame_priority.pop("Chain Pull")
 
     if time_left > TELEOP_LENGTH:
-        if min(auto_priority.values()) >= 10:
+        if min(auto_priority.values()) < 10:
             task = min(auto_priority, key=auto_priority.get)
         else:
             return None
     elif time_left <= ENDGAME_LENGTH:
-        if min(endgame_priority.values()) >= 10:
+        if min(endgame_priority.values()) < 10:
             task = min(endgame_priority, key=endgame_priority.get)
         else:
             return None
     else:
-        if min(teleop_priority.values()) >= 10:
+        if min(teleop_priority.values()) < 10:
             task = min(teleop_priority, key=teleop_priority.get)
         else:
             return None


### PR DESCRIPTION
Invert task priority logic so that priority 10 or greater results in a None task selection.